### PR TITLE
rename and split dts

### DIFF
--- a/arch/arm/boot/dts/nintendo3ds.dtsi
+++ b/arch/arm/boot/dts/nintendo3ds.dtsi
@@ -4,7 +4,7 @@
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
-	compatible = "nintendo,ctr";
+	compatible = "nintendo,3ds";
 	#address-cells = <1>;
 	#size-cells = <1>;
 

--- a/arch/arm/boot/dts/nintendo3ds.dtsi
+++ b/arch/arm/boot/dts/nintendo3ds.dtsi
@@ -1,54 +1,20 @@
 /dts-v1/;
-#include <dt-bindings/interrupt-controller/arm-gic.h>
-
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
-	model = "Nintendo 3DS (CTR)";
 	compatible = "nintendo,ctr";
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	cpus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		enable-method = "nintendo,ctr-smp";
-
-		cpu@0 {
-			device_type = "cpu";
-			compatible = "arm,arm11mpcore";
-			reg = <0>;
-		};
-
-		cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,arm11mpcore";
-			reg = <1>;
-		};
-	};
-
-	chosen {
-		/* No FB: bootargs = "earlyprintk keep_bootcon fbcon=rotate:1 init=/init"; */
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		bootargs = "nr_cpus=2 keep_bootcon fbcon=rotate:1 root=/dev/ram rw earlyprintk init=init console=tty0";
-
-		display: framebuffer@18000000 {
-			compatible = "simple-framebuffer";
-			reg = <0x18000000 (400*240*3)>;
-			width = <240>;
-			height = <400>;
-			stride = <(240*3)>;
-			format = "r8g8b8";
-		};
-
-		fcram: memory@20000000 {
-			device_type = "memory";
-			reg = <0x20000000 0x08000000>;
-		};
+	display: framebuffer@18000000 {
+		compatible = "simple-framebuffer";
+		reg = <0x18000000 (400*240*3)>;
+		width = <240>;
+		height = <400>;
+		stride = <(240*3)>;
+		format = "r8g8b8";
 	};
 
 	soc {

--- a/arch/arm/boot/dts/nintendo3ds.dtsi
+++ b/arch/arm/boot/dts/nintendo3ds.dtsi
@@ -27,17 +27,17 @@
 		interrupt-parent = <&gic>;
 
 		cfg: syscon@10140000 {
-			compatible = "nintendo,ctr-cfg-syscon", "syscon";
+			compatible = "nintendo,3ds-cfg-syscon", "syscon";
 			reg = <0x10140000 0x1000>;
 		};
 
 		pdn: syscon@10141000 {
-			compatible = "nintendo,ctr-pdn-syscon", "syscon";
+			compatible = "nintendo,3ds-pdn-syscon", "syscon";
 			reg = <0x10141000 0x1000>;
 		};
 
 		hid: hid-controller@10146000 {
-			compatible = "nintendo,ctr-gpio", "basic-mmio-gpio";
+			compatible = "nintendo,3ds-gpio", "basic-mmio-gpio";
 			reg = <0x10146000 0x2>;
 			reg-names = "dat";
 
@@ -48,7 +48,7 @@
 		};
 
 		pxi: virtio-bridge@10163000 {
-			compatible = "nintendo,ctr-pxi";
+			compatible = "nintendo,3ds-pxi";
 			reg = <0x10163000 0x10>;
 
 			interrupts =
@@ -58,7 +58,7 @@
 		};
 
 		gpio0: gpio-controller@10147000 {
-			compatible = "nintendo,ctr-gpio", "basic-mmio-gpio";
+			compatible = "nintendo,3ds-gpio", "basic-mmio-gpio";
 			reg = <0x10147000 0x2>;
 			reg-names = "dat";
 
@@ -69,7 +69,7 @@
 		};
 
 		gpio1: gpio-controller@10147010 {
-			compatible = "nintendo,ctr-gpio", "basic-mmio-gpio";
+			compatible = "nintendo,3ds-gpio", "basic-mmio-gpio";
 			reg = <0x10147010 0x1 0x10147011 0x1>;
 			reg-names = "dat", "dirout";
 
@@ -78,7 +78,7 @@
 		};
 
 		gpio2: gpio-controller@10147014 {
-			compatible = "nintendo,ctr-gpio", "basic-mmio-gpio";
+			compatible = "nintendo,3ds-gpio", "basic-mmio-gpio";
 			reg = <0x10147014 0x2>;
 			reg-names = "dat";
 
@@ -87,7 +87,7 @@
 		};
 
 		gpio3: gpio-controller@10147020 {
-			compatible = "nintendo,ctr-gpio", "basic-mmio-gpio";
+			compatible = "nintendo,3ds-gpio", "basic-mmio-gpio";
 			reg = <0x10147020 0x2 0x10147022 0x2>;
 			reg-names = "dat", "dirout";
 
@@ -96,7 +96,7 @@
 		};
 
 		gpio3irq: gpio-intc@10147024 {
-			compatible = "nintendo,ctr-gpiointc";
+			compatible = "nintendo,3ds-gpiointc";
 			reg = <0x10147024 0x4>;
 
 			gpios = <&gpio3 9 0>, <&gpio3 1 0>;
@@ -109,7 +109,7 @@
 		};
 
 		gpio4: gpio-controller@10147028 {
-			compatible = "nintendo,ctr-gpio", "basic-mmio-gpio";
+			compatible = "nintendo,3ds-gpio", "basic-mmio-gpio";
 			reg = <0x10147028 0x2>;
 			reg-names = "dat";
 
@@ -121,7 +121,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			compatible = "nintendo,ctr-i2c";
+			compatible = "nintendo,3ds-i2c";
 			reg = <0x10161000 0x1000>;
 
 			interrupts = <GIC_SPI 0x34 IRQ_TYPE_EDGE_RISING>;
@@ -131,7 +131,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			compatible = "nintendo,ctr-i2c";
+			compatible = "nintendo,3ds-i2c";
 			reg = <0x10144000 0x1000>;
 
 			interrupts = <GIC_SPI 0x35 IRQ_TYPE_EDGE_RISING>;
@@ -140,11 +140,11 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				compatible = "nintendo,ctr-mcu";
+				compatible = "nintendo,3ds-mcu";
 				reg = <0x25>;
 
 				mcuintc: mcu-intc {
-					compatible = "nintendo,ctrmcu-intc";
+					compatible = "nintendo,3dsmcu-intc";
 
 					interrupt-controller;
 					#interrupt-cells = <2>;
@@ -154,47 +154,47 @@
 				};
 
 				led: mcu-led {
-					compatible = "nintendo,ctrmcu-led";
+					compatible = "nintendo,3dsmcu-led";
 				};
 
 				rtc: mcu-rtc {
-					compatible = "nintendo,ctrmcu-rtc";
+					compatible = "nintendo,3dsmcu-rtc";
 				};
 
 				powersupply: mcu-powersupply {
-					compatible = "nintendo,ctrmcu-powersupply";
+					compatible = "nintendo,3dsmcu-powersupply";
 				};
 
 				accelerometer: mcu-accel {
-					compatible = "nintendo,ctrmcu-accel";
+					compatible = "nintendo,3dsmcu-accel";
 				};
 
 				pwroff_reg: pwroff-regulator {
-					compatible = "nintendo,ctrmcu-regulator";
+					compatible = "nintendo,3dsmcu-regulator";
 					off = <1>;
 					delay-us = <1000000>;
 				};
 
 				reboot_reg: reset-regulator {
-					compatible = "nintendo,ctrmcu-regulator";
+					compatible = "nintendo,3dsmcu-regulator";
 					off = <4>;
 					delay-us = <1000000>;
 				};
 
 				panel_reg: panel-regulator {
-					compatible = "nintendo,ctrmcu-regulator";
+					compatible = "nintendo,3dsmcu-regulator";
 					on = <17>;
 					off = <16>;
 				};
 
 				bl_top_reg: backlight-top-regulator {
-					compatible = "nintendo,ctrmcu-regulator";
+					compatible = "nintendo,3dsmcu-regulator";
 					on = <21>;
 					off = <20>;
 				};
 
 				bl_bot_reg: backlight-bottom-regulator {
-					compatible = "nintendo,ctrmcu-regulator";
+					compatible = "nintendo,3dsmcu-regulator";
 					on = <19>;
 					off = <18>;
 				};
@@ -205,7 +205,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			compatible = "nintendo,ctr-i2c";
+			compatible = "nintendo,3ds-i2c";
 			reg = <0x10148000 0x1000>;
 
 			interrupts = <GIC_SPI 0x3C IRQ_TYPE_EDGE_RISING>;
@@ -227,13 +227,13 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			compatible = "nintendo,ctr-spi";
+			compatible = "nintendo,3ds-spi";
 			reg = <0x10142800 0x800>;
 
 			interrupts = <GIC_SPI 0x37 IRQ_TYPE_EDGE_RISING>;
 
 			ts: codec@0 {
-				compatible = "nintendo,ctrspi-codec";
+				compatible = "nintendo,3dsspi-codec";
 				reg = <0>;
 
 				spi-max-frequency = <524288>;
@@ -249,7 +249,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			compatible = "nintendo,ctr-spi";
+			compatible = "nintendo,3ds-spi";
 			reg = <0x10143800 0x800>;
 
 			interrupts = <GIC_SPI 0x04 IRQ_TYPE_EDGE_RISING>;
@@ -259,7 +259,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			compatible = "nintendo,ctr-spi";
+			compatible = "nintendo,3ds-spi";
 			reg = <0x10160800 0x800>;
 
 			interrupts = <GIC_SPI 0x36 IRQ_TYPE_EDGE_RISING>;
@@ -276,7 +276,7 @@
 			compatible = "fixed-clock";
 			#clock-cells = <0>;
 			clock-frequency = <134055928>;
-			clock-output-names = "ctr:refclk134mhz";
+			clock-output-names = "3ds:refclk134mhz";
 		};
 
 		timer: twd-timer@17E00600 {

--- a/arch/arm/boot/dts/nintendo3ds_ctr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ctr.dts
@@ -8,7 +8,7 @@
 
 / {
 	model = "Nintendo 3DS (CTR)";
-	compatible = "nintendo,ctr";
+	compatible = "nintendo,ctr", "nintendo,3ds";
 
 	fcram: memory@20000000 {
 		device_type = "memory";

--- a/arch/arm/boot/dts/nintendo3ds_ctr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ctr.dts
@@ -18,7 +18,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		enable-method = "nintendo,ctr-smp";
+		enable-method = "nintendo,3ds-smp";
 
 		cpu@0 {
 			device_type = "cpu";
@@ -34,6 +34,6 @@
 	};
 
 	chosen {
-		bootargs = "nr_cpus=2 keep_bootcon fbcon=rotate:1 init=/bin/sh earlyprintk";
+		bootargs = "nr_cpus=2 keep_bootcon fbcon=rotate:1 rdinit=/bin/sh";
 	};
 };

--- a/arch/arm/boot/dts/nintendo3ds_ctr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ctr.dts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Support for the Nintendo 3DS.
+ * Support for:
+ *   - Nintendo 3DS    (CTR-001)
+ *   - Nintendo 3DS XL (SPR-001)
+ *   - Nintendo 2DS    (FTR-001)
  */
 /dts-v1/;
 

--- a/arch/arm/boot/dts/nintendo3ds_ctr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ctr.dts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Support for the Nintendo 3DS.
+ */
+/dts-v1/;
+
+#include "nintendo3ds.dtsi"
+
+/ {
+	model = "Nintendo 3DS (CTR)";
+	compatible = "nintendo,ctr";
+
+	fcram: memory@20000000 {
+		device_type = "memory";
+		reg = <0x20000000 0x08000000>;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		enable-method = "nintendo,ctr-smp";
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,arm11mpcore";
+			reg = <0>;
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,arm11mpcore";
+			reg = <1>;
+		};
+	};
+
+	chosen {
+		bootargs = "nr_cpus=2 keep_bootcon fbcon=rotate:1 init=/bin/sh earlyprintk";
+	};
+};

--- a/arch/arm/boot/dts/nintendo3ds_ktr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ktr.dts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Support for the Nintendo New 3DS.
+ */
+/dts-v1/;
+
+#include "nintendo3ds.dtsi"
+
+/ {
+	model = "Nintendo New 3DS (KTR)";
+	compatible = "nintendo,ktr", "nintendo,3ds";
+
+	fcram: memory@20000000 {
+		device_type = "memory";
+		reg = <0x20000000 0x10000000>;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		enable-method = "nintendo,ctr-smp";
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,arm11mpcore";
+			reg = <0>;
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,arm11mpcore";
+			reg = <1>;
+		};
+
+		cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,arm11mpcore";
+			reg = <2>;
+		};
+
+		cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,arm11mpcore";
+			reg = <3>;
+		};
+	};
+
+	chosen {
+		bootargs = "nr_cpus=4 keep_bootcon fbcon=rotate:1 init=/bin/sh earlyprintk";
+	};
+};

--- a/arch/arm/boot/dts/nintendo3ds_ktr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ktr.dts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Support for the Nintendo New 3DS.
+ * Support for:
+ *   - New Nintendo 3DS    (KTR-001)
+ *   - New Nintendo 3DS XL (RED-001)
  */
 /dts-v1/;
 

--- a/arch/arm/boot/dts/nintendo3ds_ktr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ktr.dts
@@ -18,7 +18,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		enable-method = "nintendo,ctr-smp";
+		enable-method = "nintendo,3ds-smp";
 
 		cpu@0 {
 			device_type = "cpu";
@@ -46,6 +46,6 @@
 	};
 
 	chosen {
-		bootargs = "nr_cpus=4 keep_bootcon fbcon=rotate:1 init=/bin/sh earlyprintk";
+		bootargs = "nr_cpus=4 keep_bootcon fbcon=rotate:1 rdinit=/bin/sh";
 	};
 };

--- a/arch/arm/boot/dts/nintendo3ds_ktr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ktr.dts
@@ -12,9 +12,12 @@
 	model = "Nintendo New 3DS (KTR)";
 	compatible = "nintendo,ktr", "nintendo,3ds";
 
+	// TODO: Once the bootloader can properly initialize the additional FCRAM,
+	// We can double these values.
+	// https://github.com/linux-3ds/linux/issues/1
 	fcram: memory@20000000 {
 		device_type = "memory";
-		reg = <0x20000000 0x10000000>;
+		reg = <0x20000000 0x08000000>;
 	};
 
 	cpus {

--- a/arch/arm/boot/dts/nintendo3ds_ktr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ktr.dts
@@ -3,6 +3,7 @@
  * Support for:
  *   - New Nintendo 3DS    (KTR-001)
  *   - New Nintendo 3DS XL (RED-001)
+ *   - New Nintendo 2DS XL (JAN-001)
  */
 /dts-v1/;
 

--- a/arch/arm/mach-ctr/main_ctr.c
+++ b/arch/arm/mach-ctr/main_ctr.c
@@ -42,7 +42,7 @@ static void __init ctr_dt_init_machine(void)
 }
 
 static const char __initconst *ctr_dt_platform_compat[] = {
-	"nintendo,ctr",
+	"nintendo,3ds",
 	NULL,
 };
 

--- a/arch/arm/mach-ctr/platsmp.c
+++ b/arch/arm/mach-ctr/platsmp.c
@@ -66,4 +66,4 @@ static const struct smp_operations ctr_smp_ops __initconst = {
 	.smp_prepare_cpus	= ctr_smp_prepare_cpus,
 	.smp_boot_secondary	= ctr_smp_boot_secondary,
 };
-CPU_METHOD_OF_DECLARE(ctr_smp, "nintendo,ctr-smp", &ctr_smp_ops);
+CPU_METHOD_OF_DECLARE(ctr_smp, "nintendo,3ds-smp", &ctr_smp_ops);

--- a/drivers/gpio/gpio-mmio.c
+++ b/drivers/gpio/gpio-mmio.c
@@ -686,7 +686,7 @@ static const struct of_device_id bgpio_of_match[] = {
 	{ .compatible = "brcm,bcm6345-gpio" },
 	{ .compatible = "wd,mbl-gpio" },
 	{ .compatible = "ni,169445-nand-gpio" },
-	{ .compatible = "nintendo,ctr-gpio" },
+	{ .compatible = "nintendo,3ds-gpio" },
 	{ }
 };
 MODULE_DEVICE_TABLE(of, bgpio_of_match);

--- a/drivers/mfd/simple-mfd-i2c.c
+++ b/drivers/mfd/simple-mfd-i2c.c
@@ -39,7 +39,7 @@ static int simple_mfd_i2c_probe(struct i2c_client *i2c)
 
 static const struct of_device_id simple_mfd_i2c_of_match[] = {
 	{ .compatible = "kontron,sl28cpld" },
-	{ .compatible = "nintendo,ctr-mcu" },
+	{ .compatible = "nintendo,3ds-mcu" },
 	{}
 };
 MODULE_DEVICE_TABLE(of, simple_mfd_i2c_of_match);

--- a/drivers/platform/nintendo3ds/ctr_codec.c
+++ b/drivers/platform/nintendo3ds/ctr_codec.c
@@ -8,7 +8,7 @@
  * Licensed under the GPL-2 or later.
  */
 
-#define DRIVER_NAME	"ctrspi-codec"
+#define DRIVER_NAME	"3dsspi-codec"
 #define pr_fmt(fmt)	DRIVER_NAME ": " fmt
 
 #include <linux/input.h>

--- a/drivers/platform/nintendo3ds/ctr_gpiointc.c
+++ b/drivers/platform/nintendo3ds/ctr_gpiointc.c
@@ -8,7 +8,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME "ctr-gpiointc"
+#define DRIVER_NAME "3ds-gpiointc"
 #define pr_fmt(fmt)	DRIVER_NAME ": " fmt
 
 #include <linux/io.h>

--- a/drivers/platform/nintendo3ds/ctr_i2c.c
+++ b/drivers/platform/nintendo3ds/ctr_i2c.c
@@ -8,7 +8,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME "ctr-i2c"
+#define DRIVER_NAME "3ds-i2c"
 #define pr_fmt(fmt)	DRIVER_NAME ": " fmt
 
 #include <linux/io.h>

--- a/drivers/platform/nintendo3ds/ctr_pxi.c
+++ b/drivers/platform/nintendo3ds/ctr_pxi.c
@@ -11,7 +11,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME "ctr-pxi"
+#define DRIVER_NAME "3ds-pxi"
 #define pr_fmt(str)	DRIVER_NAME ": " str
 
 #include <linux/io.h>

--- a/drivers/platform/nintendo3ds/ctr_spi.c
+++ b/drivers/platform/nintendo3ds/ctr_spi.c
@@ -9,7 +9,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME "ctr-spi"
+#define DRIVER_NAME "3ds-spi"
 #define pr_fmt(str)	DRIVER_NAME ": " str
 
 #include <linux/io.h>

--- a/drivers/platform/nintendo3ds/mcu/accel.c
+++ b/drivers/platform/nintendo3ds/mcu/accel.c
@@ -8,7 +8,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME	"ctrmcu-accel"
+#define DRIVER_NAME	"3dsmcu-accel"
 #define pr_fmt(fmt)	DRIVER_NAME ": " fmt
 
 /*

--- a/drivers/platform/nintendo3ds/mcu/intc.c
+++ b/drivers/platform/nintendo3ds/mcu/intc.c
@@ -8,7 +8,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME	"ctrmcu-intc"
+#define DRIVER_NAME	"3dsmcu-intc"
 #define pr_fmt(fmt)	DRIVER_NAME ": " fmt
 
 #include <linux/of.h>

--- a/drivers/platform/nintendo3ds/mcu/led.c
+++ b/drivers/platform/nintendo3ds/mcu/led.c
@@ -8,7 +8,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME	"ctrmcu-led"
+#define DRIVER_NAME	"3dsmcu-led"
 #define pr_fmt(fmt)	DRIVER_NAME ": " fmt
 
 #include <linux/of.h>

--- a/drivers/platform/nintendo3ds/mcu/powersupply.c
+++ b/drivers/platform/nintendo3ds/mcu/powersupply.c
@@ -9,7 +9,7 @@
  */
 
 
-#define DRIVER_NAME "ctrmcu-powersupply"
+#define DRIVER_NAME "3dsmcu-powersupply"
 #define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/of.h>

--- a/drivers/platform/nintendo3ds/mcu/regulator.c
+++ b/drivers/platform/nintendo3ds/mcu/regulator.c
@@ -8,7 +8,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME	"ctrmcu-regulator"
+#define DRIVER_NAME	"3dsmcu-regulator"
 #define pr_fmt(fmt)	DRIVER_NAME ": " fmt
 
 #include <linux/of.h>

--- a/drivers/platform/nintendo3ds/mcu/rtc.c
+++ b/drivers/platform/nintendo3ds/mcu/rtc.c
@@ -8,7 +8,7 @@
  * published by the Free Software Foundation.
  */
 
-#define DRIVER_NAME	"ctrmcu-rtc"
+#define DRIVER_NAME	"3dsmcu-rtc"
 #define pr_fmt(fmt)	DRIVER_NAME ": " fmt
 
 #include <linux/of.h>


### PR DESCRIPTION
The convention for sharing common features for different platforms is to
use .dtsi for describing commonalities, then .dts files for concrete
platforms.  Split the .dts file into the .dtsi, but move the cpus,
fcram, and bootargs into the machine specific .dts file.

This should enable a simple nintendo3ds_ktr.dts file to be added.

To build:
$ ARCH=arm CROSS_COMPILE=arm-linux-gnueabi- make \
  arch/arm/boot/dts/nintendo3ds_ctr.dtb

To observe what the combined DT looks like:
$ ./scripts/dtc/dtc -O dts arch/arm/boot/dts/nintendo3ds_ctr.dtb

Fixes #12
Signed-off-by: Nick Desaulniers <nick.desaulniers@gmail.com>