### PR TITLE
fix I2C driver to support the sc16is750/760

### DIFF
--- a/arch/arm/boot/dts/nintendo3ds.dtsi
+++ b/arch/arm/boot/dts/nintendo3ds.dtsi
@@ -241,7 +241,7 @@
 			sc16is750: infrared@4d {
 				compatible = "nxp,sc16is750";
 				reg = <0x4d>;
-				clock-frequency = <18432000>;
+				clocks = <&irclk>;
 
 				interrupts-extended = <&irintpin IRQ_TYPE_EDGE_FALLING>;
 
@@ -388,6 +388,13 @@
 		clock-div = <1>;
 		clock-mult = <2>;
 		clock-output-names = "3ds:refclk268mhz";
+	};
+
+	irclk: xtal18mhz {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <18432000>;
+		clock-output-names = "3ds:xtal18mhz";
 	};
 
 	poweroff: poweroff {

--- a/arch/arm/boot/dts/nintendo3ds.dtsi
+++ b/arch/arm/boot/dts/nintendo3ds.dtsi
@@ -397,13 +397,6 @@
 		clock-output-names = "3ds:refclk268mhz";
 	};
 
-	irclk: xtal18mhz {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <18432000>;
-		clock-output-names = "3ds:xtal18mhz";
-	};
-
 	poweroff: poweroff {
 		compatible = "regulator-poweroff";
 		cpu-supply = <&pwroff_reg>;


### PR DESCRIPTION
I messed up while writing the original I2C driver and ended up always reading a single byte at the end of the last transfer, this would completely break devices that rely on precious registers

although IR doesn't quite work yet (or at least my setup cant detect it) I have confirmed that now at least it gets back interrupts properly and the baudrate seems to match up with the spec