### PR TITLE
add backlight driver

### DIFF
--- a/arch/arm/boot/dts/nintendo3ds.dtsi
+++ b/arch/arm/boot/dts/nintendo3ds.dtsi
@@ -508,4 +508,14 @@
 			label = "Y";
 		};
 	};
+
+    top_backlight: top-backlight {
+		compatible = "nintendo,3ds-bl";
+		reg = <0x10202240 0x4>;
+	};
+
+    bottom_backlight: bottom-backlight {
+		compatible = "nintendo,3ds-bl";
+		reg = <0x10202a40 0x4>;
+	};
 };

--- a/drivers/platform/nintendo3ds/Kconfig
+++ b/drivers/platform/nintendo3ds/Kconfig
@@ -75,6 +75,14 @@ config CTR_I2C
 	  Nintendo 3DS I2C bus driver.
 
 
+config CTR_BL
+	tristate "Nintendo 3DS backlight driver"
+	depends on ARCH_CTR
+	default y
+	help
+	  TODO
+
+
 config CTR_MCU
 	tristate "Nintendo 3DS MCU interface"
 	depends on CTR_I2C

--- a/drivers/platform/nintendo3ds/Makefile
+++ b/drivers/platform/nintendo3ds/Makefile
@@ -10,6 +10,8 @@ obj-$(CONFIG_CTR_TSC_TOUCH)	+= tsc/touch.o
 
 obj-$(CONFIG_CTR_I2C)	+= ctr_i2c.o
 
+obj-$(CONFIG_CTR_BL)	+= ctr_bl.o
+
 # interrupt controller and regulator are
 # always enabled if the MCU is enabled
 obj-$(CONFIG_CTR_MCU)	+= mcu/intc.o

--- a/drivers/platform/nintendo3ds/ctr_bl.c
+++ b/drivers/platform/nintendo3ds/ctr_bl.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ *  ctr_i2c.c
+ *
+ *  Copyright (C) 2021 Sönke Holz
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/backlight.h>
+
+#define DRIVER_NAME "3ds-bl"
+#define MAX_BRIGHTNESS 0x3ff
+
+struct ctr_backlight {
+	void __iomem *reg;
+};
+
+static int ctr_backlight_update_status(struct backlight_device *bl)
+{
+	struct ctr_backlight *ctr_bl = bl_get_data(bl);
+
+	iowrite16(backlight_get_brightness(bl), ctr_bl->reg);
+
+	return 0;
+}
+
+static int ctr_backlight_get_brightness(struct backlight_device *bl)
+{
+	struct ctr_backlight *ctr_bl = bl_get_data(bl);
+
+	return ioread16(ctr_bl->reg);
+}
+
+static const struct backlight_ops ctr_backlight_ops = {
+	.get_brightness = ctr_backlight_get_brightness,
+	.update_status = ctr_backlight_update_status,
+	.options = BL_CORE_SUSPENDRESUME,
+};
+
+static int ctr_backlight_probe(struct platform_device *pdev)
+{
+	struct backlight_properties props;
+	struct backlight_device *bl;
+	struct ctr_backlight *ctr_bl;
+
+	ctr_bl = devm_kmalloc(&pdev->dev, sizeof(*ctr_bl), GFP_KERNEL);
+	if (IS_ERR(ctr_bl))
+		return PTR_ERR(ctr_bl);
+
+	ctr_bl->reg = devm_platform_ioremap_resource(pdev, 0);
+	if (IS_ERR(ctr_bl->reg))
+		return PTR_ERR(ctr_bl->reg);
+
+	memset(&props, 0, sizeof(props));
+	props.max_brightness = MAX_BRIGHTNESS;
+	props.type = BACKLIGHT_RAW;
+	bl = devm_backlight_device_register(&pdev->dev, pdev->name, &pdev->dev,
+					ctr_bl, &ctr_backlight_ops, &props);
+	if (IS_ERR(bl)) {
+		dev_err(&pdev->dev, "failed to register backlight\n");
+		return PTR_ERR(bl);
+	}
+
+	platform_set_drvdata(pdev, bl);
+
+	return 0;
+}
+
+static const struct of_device_id ctr_backlight_of_match[] = {
+	{ .compatible = "nintendo," DRIVER_NAME, },
+	{ /* sentinel */ },
+};
+
+MODULE_DEVICE_TABLE(of, ctr_backlight_of_match);
+
+static struct platform_driver ctr_backlight_driver = {
+	.driver	= {
+		.name	= DRIVER_NAME,
+		.owner	= THIS_MODULE,
+		.of_match_table	= of_match_ptr(ctr_backlight_of_match),
+	},
+	.probe	= ctr_backlight_probe,
+};
+
+module_platform_driver(ctr_backlight_driver);
+
+MODULE_DESCRIPTION("Nintendo 3DS backlight driver");
+MODULE_AUTHOR("Sönke Holz");
+MODULE_LICENSE("GPL");
+MODULE_ALIAS("platform:" DRIVER_NAME);


### PR DESCRIPTION
This PR adds a simple driver for the backlight of the 3DS and adds the necessary device tree entries. The brightness of both screens can be controlled via the standard sysfs backlight interface. I am not entirely sure if 0x3ff is the maximum brightness (I don't know if there is a difference after 0x1ff). But if you read the current brightness from the register, you get 0x3ff as the highest value.