### PR TITLE
remove the rdinit line in the DTS files

### DIFF
--- a/arch/arm/boot/dts/nintendo3ds_ctr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ctr.dts
@@ -37,7 +37,7 @@
 	};
 
 	chosen {
-		bootargs = "keep_bootcon fbcon=rotate:1 rdinit=/bin/sh";
+		bootargs = "keep_bootcon fbcon=rotate:1";
 	};
 };
 

--- a/arch/arm/boot/dts/nintendo3ds_ktr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ktr.dts
@@ -49,6 +49,6 @@
 	};
 
 	chosen {
-		bootargs = "keep_bootcon fbcon=rotate:1 rdinit=/bin/sh";
+		bootargs = "keep_bootcon fbcon=rotate:1";
 	};
 };


### PR DESCRIPTION
now we properly execute init and run the bootscripts
requires merging https://github.com/linux-3ds/buildroot/pull/1 and changing the workflow to use the rootfs artifact from there

it was a hack anyway