### PR TITLE
UART over IR LEDs

### DIFF
--- a/arch/arm/boot/dts/nintendo3ds.dtsi
+++ b/arch/arm/boot/dts/nintendo3ds.dtsi
@@ -125,6 +125,20 @@
 
 			interrupt-controller;
 			#interrupt-cells = <2>;
+
+			txrc_ir_hog {
+				gpio-hog;
+				gpios = <4 GPIO_ACTIVE_HIGH>;
+				output-low;
+				line-name = "IR_TXRC";
+			};
+
+			rx_ir_hog {
+				gpio-hog;
+				gpios = <5 0>;
+				input;
+				line-name = "IR_RXD";
+			};
 		};
 
 		gpio4: gpio-controller@10147028 {
@@ -241,7 +255,7 @@
 
 			interrupts = <GIC_SPI 0x3C IRQ_TYPE_EDGE_RISING>;
 
-			sc16is750: infrared@4d {
+			sc16is7xx: infrared@4d {
 				compatible = "nxp,sc16is750";
 				reg = <0x4d>;
 				clocks = <&irclk>;
@@ -250,6 +264,18 @@
 
 				gpio-controller;
 				#gpio-cells = <2>;
+
+				/*
+				 * The SC16IS7X0 is connected to a ROHM RPM841 IrDA module
+				 * This module has a PWDOWN input that needs to be
+				 * kept low if we want data to come through
+				 */
+				pwdown_low_hog {
+					gpio-hog;
+					gpios = <0 GPIO_ACTIVE_HIGH>;
+					output-low;
+					line-name = "PWDOWN";
+				};
 			};
 		};
 

--- a/arch/arm/boot/dts/nintendo3ds_ktr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ktr.dts
@@ -52,3 +52,13 @@
 		bootargs = "keep_bootcon fbcon=rotate:1";
 	};
 };
+
+&sc16is7xx {
+	/*
+	 * The new3DS has a SC16IS760 UART
+	 * Override the default choice of SC16IS750
+	 * It doesn't make much of a difference since you
+	 * can't really use the fast mode via I2C but w/e
+	 */
+	compatible = "nxp,sc16is760";
+};

--- a/drivers/tty/serial/sc16is7xx.c
+++ b/drivers/tty/serial/sc16is7xx.c
@@ -1240,25 +1240,6 @@ static int sc16is7xx_probe(struct device *dev,
 	}
 	sched_set_fifo(s->kworker_task);
 
-#ifdef CONFIG_GPIOLIB
-	if (devtype->nr_gpio) {
-		/* Setup GPIO cotroller */
-		s->gpio.owner		 = THIS_MODULE;
-		s->gpio.parent		 = dev;
-		s->gpio.label		 = dev_name(dev);
-		s->gpio.direction_input	 = sc16is7xx_gpio_direction_input;
-		s->gpio.get		 = sc16is7xx_gpio_get;
-		s->gpio.direction_output = sc16is7xx_gpio_direction_output;
-		s->gpio.set		 = sc16is7xx_gpio_set;
-		s->gpio.base		 = -1;
-		s->gpio.ngpio		 = devtype->nr_gpio;
-		s->gpio.can_sleep	 = 1;
-		ret = gpiochip_add_data(&s->gpio, s);
-		if (ret)
-			goto out_thread;
-	}
-#endif
-
 	/* reset device, purging any pending irq / data */
 	regmap_write(s->regmap, SC16IS7XX_IOCONTROL_REG << SC16IS7XX_REG_SHIFT,
 			SC16IS7XX_IOCONTROL_SRESET_BIT);
@@ -1312,6 +1293,25 @@ static int sc16is7xx_probe(struct device *dev,
 		/* Go to suspend mode */
 		sc16is7xx_power(&s->p[i].port, 0);
 	}
+
+#ifdef CONFIG_GPIOLIB
+	if (devtype->nr_gpio) {
+		/* Setup GPIO cotroller */
+		s->gpio.owner		 = THIS_MODULE;
+		s->gpio.parent		 = dev;
+		s->gpio.label		 = dev_name(dev);
+		s->gpio.direction_input	 = sc16is7xx_gpio_direction_input;
+		s->gpio.get		 = sc16is7xx_gpio_get;
+		s->gpio.direction_output = sc16is7xx_gpio_direction_output;
+		s->gpio.set		 = sc16is7xx_gpio_set;
+		s->gpio.base		 = -1;
+		s->gpio.ngpio		 = devtype->nr_gpio;
+		s->gpio.can_sleep	 = 1;
+		ret = gpiochip_add_data(&s->gpio, s);
+		if (ret)
+			goto out_thread;
+	}
+#endif
 
 	if (dev->of_node) {
 		struct property *prop;


### PR DESCRIPTION
this PR should fix the serial hardware situation so that a pure uart signal (idle high, 8 bits, no parity, start and stop bits) is transmitted over the infrared LEDs

- fixes the sc16is7xx drivers so that everything is initialized properly, not sure if this should also go in mainline ASAP
- the PWDOWN pin is properly set low so that data can come through. according to the spec sheet, when not idle it consumes 90uA and on idle it's 0.01uA, at this scale I considered it "okay" to just keep the thing on at all times
- other pins are properly set on power on and don't need to be changed at all

unfortunately this setup requires somewhat non standard hardware on the other side - most infrared transceivers respect IrDA but we don't (we're too cool for that), so the TX and RX LEDs need to be directly connected to something that can understand serial and doesn't try to perform any conversions

the above paragraph is all "in theory", as the hardware hasn't been built yet by me but we've confirmed that the TX LED does come on in the 3DS when transmitting data via microcom (/dev/ttySC0, 115200)

when the hardware is built and we have better descriptions/schematics, this'll be merged

thanks to @al3x10m for helping out the last few days by testing and gutting his IR daughterboard