### PR TITLE
small fix to make sure no line exceeds 80 chars using 8-char tabs

### DIFF
--- a/drivers/platform/nintendo3ds/ctr_gpio.c
+++ b/drivers/platform/nintendo3ds/ctr_gpio.c
@@ -54,7 +54,7 @@ static void ctr_gpio_irqhandler(struct irq_desc *desc)
 	spin_unlock_irqrestore(&gpio->gpioc.bgpio_lock, flags);
 
 	chained_irq_enter(chip, desc);
-	for_each_set_bit (irq, &pending, gpio->ngpios) {
+	for_each_set_bit(irq, &pending, gpio->ngpios) {
 		generic_handle_irq(
 			irq_find_mapping(gpio->gpioc.irq.domain, irq));
 	}

--- a/drivers/platform/nintendo3ds/ctr_gpio.c
+++ b/drivers/platform/nintendo3ds/ctr_gpio.c
@@ -62,7 +62,7 @@ static void ctr_gpio_irqhandler(struct irq_desc *desc)
 }
 
 static void ctr_gpio_irq_toggle(struct ctr_gpio *gpio,
-								unsigned irq, unsigned enable)
+				unsigned irq, unsigned enable)
 {
 	u8 mask;
 	unsigned offset;
@@ -165,7 +165,7 @@ static int ctr_gpiointc_probe(struct platform_device *pdev)
 	}
 
 	err = bgpio_init(&gpio->gpioc, dev, nregs, gpio->dat,
-					gpio->dat, NULL, gpio->dir, NULL, bgpio_flags);
+			gpio->dat, NULL, gpio->dir, NULL, bgpio_flags);
 	if (err)
 		return err;
 
@@ -187,7 +187,7 @@ static int ctr_gpiointc_probe(struct platform_device *pdev)
 		girq->parent_handler = ctr_gpio_irqhandler;
 		girq->num_parents = irq_count;
 		girq->parents = devm_kcalloc(dev, irq_count,
-									sizeof(*girq->parents), GFP_KERNEL);
+					sizeof(*girq->parents), GFP_KERNEL);
 		if (!girq->parents)
 			return -ENOMEM;
 

--- a/drivers/platform/nintendo3ds/ctr_gpio.c
+++ b/drivers/platform/nintendo3ds/ctr_gpio.c
@@ -6,7 +6,7 @@
  */
 
 #define DRIVER_NAME "3ds-gpio"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/io.h>
 #include <linux/irq.h>
@@ -54,15 +54,15 @@ static void ctr_gpio_irqhandler(struct irq_desc *desc)
 	spin_unlock_irqrestore(&gpio->gpioc.bgpio_lock, flags);
 
 	chained_irq_enter(chip, desc);
-	for_each_set_bit(irq, &pending, gpio->ngpios) {
+	for_each_set_bit (irq, &pending, gpio->ngpios) {
 		generic_handle_irq(
 			irq_find_mapping(gpio->gpioc.irq.domain, irq));
 	}
 	chained_irq_exit(chip, desc);
 }
 
-static void ctr_gpio_irq_toggle(struct ctr_gpio *gpio,
-				unsigned irq, unsigned enable)
+static void ctr_gpio_irq_toggle(struct ctr_gpio *gpio, unsigned irq,
+				unsigned enable)
 {
 	u8 mask;
 	unsigned offset;
@@ -164,8 +164,8 @@ static int ctr_gpiointc_probe(struct platform_device *pdev)
 		bgpio_flags = 0;
 	}
 
-	err = bgpio_init(&gpio->gpioc, dev, nregs, gpio->dat,
-			gpio->dat, NULL, gpio->dir, NULL, bgpio_flags);
+	err = bgpio_init(&gpio->gpioc, dev, nregs, gpio->dat, gpio->dat, NULL,
+			 gpio->dir, NULL, bgpio_flags);
 	if (err)
 		return err;
 
@@ -186,8 +186,8 @@ static int ctr_gpiointc_probe(struct platform_device *pdev)
 		girq->chip = &gpio->irqc;
 		girq->parent_handler = ctr_gpio_irqhandler;
 		girq->num_parents = irq_count;
-		girq->parents = devm_kcalloc(dev, irq_count,
-					sizeof(*girq->parents), GFP_KERNEL);
+		girq->parents = devm_kcalloc(
+			dev, irq_count, sizeof(*girq->parents), GFP_KERNEL);
 		if (!girq->parents)
 			return -ENOMEM;
 
@@ -203,7 +203,7 @@ static int ctr_gpiointc_probe(struct platform_device *pdev)
 
 static const struct of_device_id ctr_gpiointc_of_match[] = {
 	{ .compatible = "nintendo," DRIVER_NAME },
-	{ },
+	{},
 };
 MODULE_DEVICE_TABLE(of, ctr_gpiointc_of_match);
 

--- a/drivers/platform/nintendo3ds/ctr_i2c.c
+++ b/drivers/platform/nintendo3ds/ctr_i2c.c
@@ -6,7 +6,7 @@
  */
 
 #define DRIVER_NAME "3ds-i2c"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/io.h>
 #include <linux/i2c.h>
@@ -39,34 +39,41 @@ struct ctr_i2c {
 	struct i2c_adapter adap;
 };
 
-static u8 ctr_i2c_read_data(struct ctr_i2c *i2c) {
+static u8 ctr_i2c_read_data(struct ctr_i2c *i2c)
+{
 	return ioread8(i2c->base + 0x00);
 }
 
-static u8 ctr_i2c_read_cnt(struct ctr_i2c *i2c) {
+static u8 ctr_i2c_read_cnt(struct ctr_i2c *i2c)
+{
 	return ioread8(i2c->base + 0x01);
 }
 
-static void ctr_i2c_write_data(struct ctr_i2c *i2c, u8 val) {
+static void ctr_i2c_write_data(struct ctr_i2c *i2c, u8 val)
+{
 	iowrite8(val, i2c->base + 0x00);
 }
 
-static void ctr_i2c_write_cnt(struct ctr_i2c *i2c, u8 val) {
+static void ctr_i2c_write_cnt(struct ctr_i2c *i2c, u8 val)
+{
 	iowrite8(val, i2c->base + 0x01);
 }
 
-static void ctr_i2c_write_cntex(struct ctr_i2c *i2c, u16 cntex) {
+static void ctr_i2c_write_cntex(struct ctr_i2c *i2c, u16 cntex)
+{
 	iowrite16(cntex, i2c->base + 0x02);
 }
 
-static void ctr_i2c_write_scl(struct ctr_i2c *i2c, u16 scl) {
+static void ctr_i2c_write_scl(struct ctr_i2c *i2c, u16 scl)
+{
 	iowrite16(scl, i2c->base + 0x04);
 }
 
 static int ctr_i2c_wait_busy(struct ctr_i2c *i2c)
 {
-	long res = wait_event_interruptible_timeout(i2c->wq,
-		!(ctr_i2c_read_cnt(i2c) & I2C_CNT_BUSY), CTR_I2C_TIMEOUT);
+	long res = wait_event_interruptible_timeout(
+		i2c->wq, !(ctr_i2c_read_cnt(i2c) & I2C_CNT_BUSY),
+		CTR_I2C_TIMEOUT);
 
 	if (res > 0)
 		return 0;
@@ -78,16 +85,16 @@ static int ctr_i2c_wait_busy(struct ctr_i2c *i2c)
 static int ctr_i2c_send(struct ctr_i2c *i2c, u8 byte, unsigned flags)
 {
 	ctr_i2c_write_data(i2c, byte);
-	ctr_i2c_write_cnt(i2c, I2C_CNT_BUSY | I2C_CNT_IRQEN |
-		I2C_CNT_WRITE | flags);
+	ctr_i2c_write_cnt(i2c,
+			  I2C_CNT_BUSY | I2C_CNT_IRQEN | I2C_CNT_WRITE | flags);
 	return ctr_i2c_wait_busy(i2c);
 }
 
 static int ctr_i2c_recv(struct ctr_i2c *i2c, u8 *byte, unsigned flags)
 {
 	int err;
-	ctr_i2c_write_cnt(i2c, I2C_CNT_BUSY | I2C_CNT_IRQEN |
-		I2C_CNT_READ | flags);
+	ctr_i2c_write_cnt(i2c,
+			  I2C_CNT_BUSY | I2C_CNT_IRQEN | I2C_CNT_READ | flags);
 	err = ctr_i2c_wait_busy(i2c);
 	*byte = ctr_i2c_read_data(i2c);
 	return err;
@@ -102,7 +109,8 @@ static int ctr_i2c_msg_read(struct ctr_i2c *i2c, u8 *buf, int len, bool last)
 {
 	int i;
 	for (i = 0; i < len; i++) {
-		unsigned flag = (last && (i==(len-1))) ? I2C_CNT_LAST : I2C_CNT_ERRACK;
+		unsigned flag = (last && (i == (len - 1))) ? I2C_CNT_LAST :
+							     I2C_CNT_ERRACK;
 		if (ctr_i2c_recv(i2c, &buf[i], flag))
 			return i;
 	}
@@ -113,21 +121,22 @@ static int ctr_i2c_msg_write(struct ctr_i2c *i2c, u8 *buf, int len, bool last)
 {
 	int i;
 	for (i = 0; i < len; i++) {
-		unsigned flag = (last && (i==(len-1))) ? I2C_CNT_LAST : 0;
+		unsigned flag = (last && (i == (len - 1))) ? I2C_CNT_LAST : 0;
 		if (ctr_i2c_send(i2c, buf[i], flag))
 			return i;
 
 		if (!(ctr_i2c_read_cnt(i2c) & I2C_CNT_ERRACK)) {
 			ctr_i2c_write_cnt(i2c, I2C_CNT_BUSY | I2C_CNT_IRQEN |
-				I2C_CNT_PAUSE | I2C_CNT_WRITE);
+						       I2C_CNT_PAUSE |
+						       I2C_CNT_WRITE);
 			return i;
 		}
 	}
 	return len;
 }
 
-static int ctr_i2c_master_xfer(struct i2c_adapter *adap,
-				struct i2c_msg *msgs, int num)
+static int ctr_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+			       int num)
 {
 	int i, plen;
 	struct i2c_msg *msg;
@@ -143,11 +152,13 @@ static int ctr_i2c_master_xfer(struct i2c_adapter *adap,
 			ctr_i2c_select_device(i2c, msg);
 
 		if (msg->len != 0) {
-			bool last = i == (num-1);
+			bool last = i == (num - 1);
 			if (msg->flags & I2C_M_RD) {
-				plen = ctr_i2c_msg_read(i2c, msg->buf, msg->len, last);
+				plen = ctr_i2c_msg_read(i2c, msg->buf, msg->len,
+							last);
 			} else {
-				plen = ctr_i2c_msg_write(i2c, msg->buf, msg->len, last);
+				plen = ctr_i2c_msg_write(i2c, msg->buf,
+							 msg->len, last);
 			}
 
 			if (plen != msg->len)
@@ -201,8 +212,8 @@ static int ctr_i2c_probe(struct platform_device *pdev)
 	if (!i2c->irq)
 		return -EINVAL;
 
-	err = devm_request_irq(dev, i2c->irq,
-		ctr_i2c_irq, 0, dev_name(dev), i2c);
+	err = devm_request_irq(dev, i2c->irq, ctr_i2c_irq, 0, dev_name(dev),
+			       i2c);
 	if (err)
 		return err;
 
@@ -212,11 +223,11 @@ static int ctr_i2c_probe(struct platform_device *pdev)
 	ctr_i2c_write_scl(i2c, 5 << 8);
 
 	/* setup the i2c_adapter */
-	adap->owner		= THIS_MODULE;
+	adap->owner	= THIS_MODULE;
 	strlcpy(adap->name, dev_name(dev), sizeof(adap->name));
 	adap->dev.parent	= dev;
 	adap->dev.of_node	= dev->of_node;
-	adap->algo		= &ctr_i2c_algo;
+	adap->algo	= &ctr_i2c_algo;
 	adap->algo_data	= i2c;
 
 	dev_set_drvdata(dev, i2c);
@@ -231,8 +242,8 @@ static int ctr_i2c_remove(struct platform_device *pdev)
 }
 
 static const struct of_device_id ctr_i2c_of_match[] = {
-	{ .compatible = "nintendo," DRIVER_NAME, },
-	{ },
+	{ .compatible = "nintendo," DRIVER_NAME },
+	{},
 };
 MODULE_DEVICE_TABLE(of, ctr_i2c_of_match);
 

--- a/drivers/platform/nintendo3ds/ctr_i2c.c
+++ b/drivers/platform/nintendo3ds/ctr_i2c.c
@@ -65,9 +65,8 @@ static void ctr_i2c_write_scl(struct ctr_i2c *i2c, u16 scl) {
 
 static int ctr_i2c_wait_busy(struct ctr_i2c *i2c)
 {
-	long res = wait_event_interruptible_timeout(
-		i2c->wq, !(ctr_i2c_read_cnt(i2c) & I2C_CNT_BUSY), CTR_I2C_TIMEOUT
-	);
+	long res = wait_event_interruptible_timeout(i2c->wq,
+		!(ctr_i2c_read_cnt(i2c) & I2C_CNT_BUSY), CTR_I2C_TIMEOUT);
 
 	if (res > 0)
 		return 0;
@@ -128,7 +127,7 @@ static int ctr_i2c_msg_write(struct ctr_i2c *i2c, u8 *buf, int len, bool last)
 }
 
 static int ctr_i2c_master_xfer(struct i2c_adapter *adap,
-			struct i2c_msg *msgs, int num)
+				struct i2c_msg *msgs, int num)
 {
 	int i, plen;
 	struct i2c_msg *msg;
@@ -215,7 +214,7 @@ static int ctr_i2c_probe(struct platform_device *pdev)
 	/* setup the i2c_adapter */
 	adap->owner		= THIS_MODULE;
 	strlcpy(adap->name, dev_name(dev), sizeof(adap->name));
-	adap->dev.parent 	= dev;
+	adap->dev.parent	= dev;
 	adap->dev.of_node	= dev->of_node;
 	adap->algo		= &ctr_i2c_algo;
 	adap->algo_data	= i2c;

--- a/drivers/platform/nintendo3ds/ctr_pxi.c
+++ b/drivers/platform/nintendo3ds/ctr_pxi.c
@@ -480,7 +480,7 @@ static void vpxi_irq_worker(struct work_struct *work)
 		if (pending_mask & BIT(qirq)) {
 			unsigned long flags;
 			spin_lock_irqsave(&vpd->lock, flags);
-			list_for_each_entry (info, &vpd->vqs, node)
+			list_for_each_entry(info, &vpd->vqs, node)
 				vring_interrupt(0, info->vq);
 			spin_unlock_irqrestore(&vpd->lock, flags);
 		}

--- a/drivers/platform/nintendo3ds/ctr_pxi.h
+++ b/drivers/platform/nintendo3ds/ctr_pxi.h
@@ -88,7 +88,8 @@
 #define VPXI_REG_MANAGER_IRQ_VQUEUE(b)	VPXI_REG_MANAGER(0x08 + ((b) & 3))
 #define VPXI_REG_MANAGER_IRQ_CONFIG(b)	VPXI_REG_MANAGER(0x0C + ((b) & 3))
 
-#define VPXI_MAX_IRQBANK	(VPXI_MAXDEV / 32) /* 32 int bits per register */
+/* 32 int bits per register */
+#define VPXI_MAX_IRQBANK	(VPXI_MAXDEV / 32)
 
 #define to_vpxi_dev(_vd) \
 	container_of(_vd, struct virtio_pxi_dev, vdev)

--- a/drivers/platform/nintendo3ds/ctr_sdhc.c
+++ b/drivers/platform/nintendo3ds/ctr_sdhc.c
@@ -210,7 +210,7 @@ static void ctr_sdhc_respend_irq(struct ctr_sdhc *host)
 		return;
 	}
 
-	respbuf = (u32 *)cmd->resp;
+	respbuf = (u32*)cmd->resp;
 	host->cmd = NULL;
 
 	for (i = 0, reg = SDHC_CMD_RESPONSE; i < 4; i++, reg += 4)

--- a/drivers/platform/nintendo3ds/ctr_sdhc.c
+++ b/drivers/platform/nintendo3ds/ctr_sdhc.c
@@ -189,10 +189,13 @@ static irqreturn_t ctr_sdhc_thread_irq(int irq, void *dev_id)
 	dev_dbg(host->dev, "count: %08x, flags %08x\n", count,
 		data->flags);
 
-	if (data->flags & MMC_DATA_READ)
-		ioread16_rep(host->regs + SDHC_DATA16_FIFO_PORT, buf, count >> 1);
-	else
-		iowrite16_rep(host->regs + SDHC_DATA16_FIFO_PORT, buf, count >> 1);
+	if (data->flags & MMC_DATA_READ) {
+		ioread16_rep(host->regs + SDHC_DATA16_FIFO_PORT,
+			buf, count >> 1);
+	} else {
+		iowrite16_rep(host->regs + SDHC_DATA16_FIFO_PORT,
+			buf, count >> 1);
+	}
 
 	sg_miter->consumed = count;
 	sg_miter_stop(sg_miter);
@@ -270,7 +273,8 @@ static irqreturn_t ctr_sdhc_irq(int irq, void *dev_id)
 	} else if (int_reg & SDHC_ERR_CRC_FAIL) {
 		error = -EILSEQ;
 	} else if (int_reg & SDHC_ERR_MASK) {
-		dev_err(host->dev, "buffer error: %08X\n", int_reg & SDHC_ERR_MASK);
+		dev_err(host->dev, "buffer error: %08X\n",
+			int_reg & SDHC_ERR_MASK);
 		dev_err(host->dev, "detail error status %08X\n",
 			ioread32(host->regs + SDHC_ERROR_STATUS));
 		error = -EIO;
@@ -395,7 +399,9 @@ static void ctr_sdhc_start_data(struct ctr_sdhc *host, struct mmc_data *data)
 {
 	unsigned int flags = SG_MITER_ATOMIC;
 
-	dev_dbg(host->dev, "setup data transfer: blocksize %08x  nr_blocks %d, offset: %08x\n",
+	dev_dbg(host->dev,
+		"setup data transfer: blocksize %08x "
+		"nr_blocks %d, offset: %08x\n",
 		data->blksz, data->blocks, data->sg->offset);
 
 	host->data = data;
@@ -456,7 +462,8 @@ static int ctr_sdhc_get_ro(struct mmc_host *mmc)
 static int ctr_sdhc_get_cd(struct mmc_host *mmc)
 {
 	struct ctr_sdhc *host = mmc_priv(mmc);
-	return !!(ioread16(host->regs + SDHC_IRQ_STAT) & SDHC_STAT_CARDPRESENT);
+	return !!(ioread16(host->regs + SDHC_IRQ_STAT) &
+		SDHC_STAT_CARDPRESENT);
 }
 
 static void ctr_sdhc_enable_sdio_irq(struct mmc_host *mmc, int enable)
@@ -548,13 +555,13 @@ static int ctr_sdhc_probe(struct platform_device *pdev)
 	ctr_sdhc_reset(host);
 
 	ret = devm_request_threaded_irq(dev, platform_get_irq(pdev, 0),
-									ctr_sdhc_irq, ctr_sdhc_thread_irq,
-									IRQF_SHARED, DRIVER_NAME, host);
+					ctr_sdhc_irq, ctr_sdhc_thread_irq,
+					IRQF_SHARED, DRIVER_NAME, host);
 	if (ret)
 		goto free_mmc;
 
 	ret = devm_request_irq(dev, platform_get_irq(pdev, 1),
-						ctr_sdhc_sdio_irq, 0, DRIVER_NAME, host);
+				ctr_sdhc_sdio_irq, 0, DRIVER_NAME, host);
 	if (ret)
 		goto free_mmc;
 

--- a/drivers/platform/nintendo3ds/ctr_sdhc.c
+++ b/drivers/platform/nintendo3ds/ctr_sdhc.c
@@ -8,7 +8,7 @@
  */
 
 #define DRIVER_NAME "3ds-sdhc"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/io.h>
 #include <linux/of.h>
@@ -27,17 +27,15 @@
 
 #include "ctr_sdhc.h"
 
-#define SDHC_ERR_MASK	( \
-	SDHC_ERR_BAD_CMD | SDHC_ERR_CRC_FAIL | \
-	SDHC_ERR_STOP_BIT | SDHC_ERR_DATATIMEOUT | \
-	SDHC_ERR_TX_OVERFLOW | SDHC_ERR_RX_UNDERRUN | \
-	SDHC_ERR_CMD_TIMEOUT | SDHC_ERR_ILLEGAL_ACC)
+#define SDHC_ERR_MASK                                                          \
+	(SDHC_ERR_BAD_CMD | SDHC_ERR_CRC_FAIL | SDHC_ERR_STOP_BIT |            \
+	 SDHC_ERR_DATATIMEOUT | SDHC_ERR_TX_OVERFLOW | SDHC_ERR_RX_UNDERRUN |  \
+	 SDHC_ERR_CMD_TIMEOUT | SDHC_ERR_ILLEGAL_ACC)
 
-#define SDHC_DEFAULT_IRQMASK	( \
-	SDHC_STAT_CMDRESPEND | SDHC_STAT_DATA_END | \
-	SDHC_STAT_RX_READY | SDHC_STAT_TX_REQUEST | \
-	SDHC_STAT_CARDREMOVE | SDHC_STAT_CARDINSERT | \
-	SDHC_ERR_MASK)
+#define SDHC_DEFAULT_IRQMASK                                                   \
+	(SDHC_STAT_CMDRESPEND | SDHC_STAT_DATA_END | SDHC_STAT_RX_READY |      \
+	 SDHC_STAT_TX_REQUEST | SDHC_STAT_CARDREMOVE | SDHC_STAT_CARDINSERT |  \
+	 SDHC_ERR_MASK)
 
 static void ctr_sdhc_reset(struct ctr_sdhc *host)
 {
@@ -66,7 +64,7 @@ static void ctr_sdhc_reset(struct ctr_sdhc *host)
 	iowrite32(0, host->regs + SDHC_IRQ_STAT);
 
 	iowrite16(SDHC_CARD_OPTION_1BIT | SDHC_CARD_OPTION_NOC2,
-		host->regs + SDHC_CARD_OPTION);
+		  host->regs + SDHC_CARD_OPTION);
 }
 
 static void __ctr_sdhc_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
@@ -90,7 +88,7 @@ static void __ctr_sdhc_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
 		int clk_div = -1;
 		unsigned clk_fit = clk_get_rate(host->sdclk) / 2;
 
-		while((ios->clock < clk_fit) && (clk_div < 7)) {
+		while ((ios->clock < clk_fit) && (clk_div < 7)) {
 			clk_div++;
 			clk_fit >>= 1;
 		}
@@ -109,18 +107,16 @@ static void __ctr_sdhc_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
 		break;
 
 	case MMC_BUS_WIDTH_1:
-		iowrite16(SDHC_CARD_OPTION_RETRIES(14)
-				| SDHC_CARD_OPTION_TIMEOUT(14)
-				| SDHC_CARD_OPTION_NOC2
-				| SDHC_CARD_OPTION_1BIT,
-				host->regs + SDHC_CARD_OPTION);
+		iowrite16(SDHC_CARD_OPTION_RETRIES(14) |
+				  SDHC_CARD_OPTION_TIMEOUT(14) |
+				  SDHC_CARD_OPTION_NOC2 | SDHC_CARD_OPTION_1BIT,
+			  host->regs + SDHC_CARD_OPTION);
 		break;
 	case MMC_BUS_WIDTH_4:
-		iowrite16(SDHC_CARD_OPTION_RETRIES(14)
-				| SDHC_CARD_OPTION_TIMEOUT(14)
-				| SDHC_CARD_OPTION_NOC2
-				| SDHC_CARD_OPTION_4BIT,
-				host->regs + SDHC_CARD_OPTION);
+		iowrite16(SDHC_CARD_OPTION_RETRIES(14) |
+				  SDHC_CARD_OPTION_TIMEOUT(14) |
+				  SDHC_CARD_OPTION_NOC2 | SDHC_CARD_OPTION_4BIT,
+			  host->regs + SDHC_CARD_OPTION);
 		break;
 	}
 }
@@ -186,15 +182,14 @@ static irqreturn_t ctr_sdhc_thread_irq(int irq, void *dev_id)
 	if (count > data->blksz)
 		count = data->blksz;
 
-	dev_dbg(host->dev, "count: %08x, flags %08x\n", count,
-		data->flags);
+	dev_dbg(host->dev, "count: %08x, flags %08x\n", count, data->flags);
 
 	if (data->flags & MMC_DATA_READ) {
-		ioread16_rep(host->regs + SDHC_DATA16_FIFO_PORT,
-			buf, count >> 1);
+		ioread16_rep(host->regs + SDHC_DATA16_FIFO_PORT, buf,
+			     count >> 1);
 	} else {
-		iowrite16_rep(host->regs + SDHC_DATA16_FIFO_PORT,
-			buf, count >> 1);
+		iowrite16_rep(host->regs + SDHC_DATA16_FIFO_PORT, buf,
+			      count >> 1);
 	}
 
 	sg_miter->consumed = count;
@@ -215,7 +210,7 @@ static void ctr_sdhc_respend_irq(struct ctr_sdhc *host)
 		return;
 	}
 
-	respbuf = (u32*)cmd->resp;
+	respbuf = (u32 *)cmd->resp;
 	host->cmd = NULL;
 
 	for (i = 0, reg = SDHC_CMD_RESPONSE; i < 4; i++, reg += 4)
@@ -230,8 +225,8 @@ static void ctr_sdhc_respend_irq(struct ctr_sdhc *host)
 		respbuf[0] = response[0];
 	}
 
-	dev_dbg(host->dev, "Command IRQ complete %d %d %x\n",
-		cmd->opcode, cmd->error, cmd->flags);
+	dev_dbg(host->dev, "Command IRQ complete %d %d %x\n", cmd->opcode,
+		cmd->error, cmd->flags);
 
 	/* If there is data to handle we will
 	 * finish the request in the data end irq handler.*/
@@ -260,7 +255,7 @@ static irqreturn_t ctr_sdhc_irq(int irq, void *dev_id)
 	}
 
 	iowrite32(~(int_reg & SDHC_DEFAULT_IRQMASK),
-		host->regs + SDHC_IRQ_STAT);
+		  host->regs + SDHC_IRQ_STAT);
 
 	if (int_reg & (SDHC_STAT_CARDREMOVE | SDHC_STAT_CARDINSERT)) {
 		if (int_reg & SDHC_STAT_CARDPRESENT)
@@ -291,7 +286,7 @@ static irqreturn_t ctr_sdhc_irq(int irq, void *dev_id)
 		}
 	}
 
-	if (int_reg & (SDHC_STAT_RX_READY | SDHC_STAT_TX_REQUEST)) {		
+	if (int_reg & (SDHC_STAT_RX_READY | SDHC_STAT_TX_REQUEST)) {
 		ret = IRQ_WAKE_THREAD;
 		goto irq_end;
 	}
@@ -462,8 +457,7 @@ static int ctr_sdhc_get_ro(struct mmc_host *mmc)
 static int ctr_sdhc_get_cd(struct mmc_host *mmc)
 {
 	struct ctr_sdhc *host = mmc_priv(mmc);
-	return !!(ioread16(host->regs + SDHC_IRQ_STAT) &
-		SDHC_STAT_CARDPRESENT);
+	return !!(ioread16(host->regs + SDHC_IRQ_STAT) & SDHC_STAT_CARDPRESENT);
 }
 
 static void ctr_sdhc_enable_sdio_irq(struct mmc_host *mmc, int enable)
@@ -561,7 +555,7 @@ static int ctr_sdhc_probe(struct platform_device *pdev)
 		goto free_mmc;
 
 	ret = devm_request_irq(dev, platform_get_irq(pdev, 1),
-				ctr_sdhc_sdio_irq, 0, DRIVER_NAME, host);
+			       ctr_sdhc_sdio_irq, 0, DRIVER_NAME, host);
 	if (ret)
 		goto free_mmc;
 
@@ -574,25 +568,22 @@ free_mmc:
 	return ret;
 }
 
-static const struct dev_pm_ops ctr_sdhc_pm_ops = {
-	SET_SYSTEM_SLEEP_PM_OPS(ctr_sdhc_pm_suspend, ctr_sdhc_pm_resume)
-};
+static const struct dev_pm_ops ctr_sdhc_pm_ops = { SET_SYSTEM_SLEEP_PM_OPS(
+	ctr_sdhc_pm_suspend, ctr_sdhc_pm_resume) };
 
 static const struct of_device_id ctr_sdhc_of_match[] = {
 	{ .compatible = "nintendo," DRIVER_NAME },
-	{ },
+	{},
 };
 MODULE_DEVICE_TABLE(of, ctr_sdhc_of_match);
 
 static struct platform_driver ctr_sdhc_driver = {
-	.probe		= ctr_sdhc_probe,
+	.probe = ctr_sdhc_probe,
 
-	.driver		= {
-		.name	= DRIVER_NAME,
-		.owner	= THIS_MODULE,
-		.of_match_table = of_match_ptr(ctr_sdhc_of_match),
-		.pm	= &ctr_sdhc_pm_ops
-	},
+	.driver = { .name = DRIVER_NAME,
+		    .owner = THIS_MODULE,
+		    .of_match_table = of_match_ptr(ctr_sdhc_of_match),
+		    .pm = &ctr_sdhc_pm_ops },
 };
 
 module_platform_driver(ctr_sdhc_driver);

--- a/drivers/platform/nintendo3ds/ctr_spi.c
+++ b/drivers/platform/nintendo3ds/ctr_spi.c
@@ -7,7 +7,7 @@
  */
 
 #define DRIVER_NAME "3ds-spi"
-#define pr_fmt(str)	DRIVER_NAME ": " str
+#define pr_fmt(str) DRIVER_NAME ": " str
 
 #include <linux/io.h>
 #include <linux/of.h>
@@ -32,8 +32,8 @@ struct ctr_spi {
 #define SPI_CNT_CHIPSELECT(n)	((n) << 6)
 #define SPI_CNT_XFER_READ	(0 << 13)
 #define SPI_CNT_XFER_WRITE	(1 << 13)
-#define SPI_CNT_BUSY		BIT(15)
-#define SPI_CNT_ENABLE		BIT(15)
+#define SPI_CNT_BUSY	BIT(15)
+#define SPI_CNT_ENABLE	BIT(15)
 
 #define SPI_FIFO_BUSY	BIT(0)
 #define SPI_FIFO_WIDTH	0x20
@@ -50,7 +50,7 @@ static u32 ctr_spi_freq_to_rate(u32 freq)
 	 4 -> 8MHz
 	 5,6,7 -> 16MHz
 	*/
-	return min(ilog2(max_t(u32, freq, 1<<19)>>19), 5);
+	return min(ilog2(max_t(u32, freq, 1 << 19) >> 19), 5);
 }
 
 static void ctr_spi_write_cnt(struct ctr_spi *spi, u32 cnt)
@@ -85,9 +85,9 @@ static u32 ctr_spi_read_status(struct ctr_spi *spi)
 
 static int ctr_spi_wait_busy(struct ctr_spi *spi)
 {
-	long res = wait_event_interruptible_timeout(spi->wq,
-		!(ctr_spi_read_cnt(spi) & SPI_CNT_BUSY), CTR_SPI_TIMEOUT
-	);
+	long res = wait_event_interruptible_timeout(
+		spi->wq, !(ctr_spi_read_cnt(spi) & SPI_CNT_BUSY),
+		CTR_SPI_TIMEOUT);
 
 	if (res > 0)
 		return 0;
@@ -98,7 +98,7 @@ static int ctr_spi_wait_busy(struct ctr_spi *spi)
 
 static int ctr_spi_wait_fifo(struct ctr_spi *spi)
 {
-	while(ctr_spi_read_status(spi) & SPI_FIFO_BUSY)
+	while (ctr_spi_read_status(spi) & SPI_FIFO_BUSY)
 		usleep_range(1, 5);
 	return 0;
 }
@@ -106,19 +106,20 @@ static int ctr_spi_wait_fifo(struct ctr_spi *spi)
 static int ctr_spi_done(struct ctr_spi *spi)
 {
 	int err = ctr_spi_wait_busy(spi);
-	if (err) return err;
+	if (err)
+		return err;
 	iowrite32(0, spi->base + 0x04);
 	return 0;
 }
 
-static void ctr_spi_setup_xfer(struct ctr_spi *spidrv,
-				struct spi_device *spi, bool read)
+static void ctr_spi_setup_xfer(struct ctr_spi *spidrv, struct spi_device *spi,
+			       bool read)
 {
-	ctr_spi_write_cnt(spidrv, SPI_CNT_ENABLE |
-		ctr_spi_freq_to_rate(spi->max_speed_hz) |
-		SPI_CNT_CHIPSELECT(spidrv->cs) |
-		(read ? SPI_CNT_XFER_READ : SPI_CNT_XFER_WRITE)
-	);
+	ctr_spi_write_cnt(
+		spidrv,
+		SPI_CNT_ENABLE | ctr_spi_freq_to_rate(spi->max_speed_hz) |
+			SPI_CNT_CHIPSELECT(spidrv->cs) |
+			(read ? SPI_CNT_XFER_READ : SPI_CNT_XFER_WRITE));
 }
 
 static int ctr_spi_xfer_read(struct ctr_spi *spibus, u32 *buf, u32 len)
@@ -126,10 +127,11 @@ static int ctr_spi_xfer_read(struct ctr_spi *spibus, u32 *buf, u32 len)
 	u32 idx = 0;
 	do {
 		int err = ctr_spi_wait_fifo(spibus);
-		if (err) return err;
+		if (err)
+			return err;
 		*(buf++) = ctr_spi_read_fifo(spibus);
 		idx += 4;
-	} while(idx < len);
+	} while (idx < len);
 
 	return 0;
 }
@@ -139,10 +141,11 @@ static int ctr_spi_xfer_write(struct ctr_spi *spibus, u32 *buf, u32 len)
 	u32 idx = 0;
 	do {
 		int err = ctr_spi_wait_fifo(spibus);
-		if (err) return err;
+		if (err)
+			return err;
 		ctr_spi_write_fifo(spibus, *(buf++));
 		idx += 4;
-	} while(idx < len);
+	} while (idx < len);
 
 	return 0;
 }
@@ -166,10 +169,10 @@ static int ctr_spi_transfer_one(struct spi_master *master,
 
 	if (xfer->tx_buf) {
 		read = false;
-		buf = (u32*)xfer->tx_buf;
+		buf = (u32 *)xfer->tx_buf;
 	} else if (xfer->rx_buf) {
 		read = true;
-		buf = (u32*)xfer->rx_buf;
+		buf = (u32 *)xfer->rx_buf;
 	} else {
 		return -EINVAL;
 	}
@@ -228,8 +231,8 @@ static int ctr_spi_probe(struct platform_device *pdev)
 
 	/* set up the spi device structure */
 	spi->master = master;
-	master->bus_num = pdev->id;
-	master->set_cs = ctr_spi_set_cs;
+	master->bus_num	= pdev->id;
+	master->set_cs	= ctr_spi_set_cs;
 	master->transfer_one = ctr_spi_transfer_one;
 	master->max_transfer_size = ctr_spi_max_transfer_size;
 	master->num_chipselect = 3;
@@ -248,8 +251,8 @@ static int ctr_spi_probe(struct platform_device *pdev)
 	iowrite32(~BIT(0), spi->base + 0x18); // mask
 	iowrite32(~0, spi->base + 0x1C); // acknowledge
 
-	err = devm_request_irq(dev, platform_get_irq(pdev, 0),
-		ctr_spi_irq, 0, DRIVER_NAME, spi);
+	err = devm_request_irq(dev, platform_get_irq(pdev, 0), ctr_spi_irq, 0,
+			       DRIVER_NAME, spi);
 	if (err)
 		return err;
 
@@ -262,7 +265,7 @@ static int ctr_spi_remove(struct platform_device *pdev)
 }
 
 static const struct of_device_id ctr_spi_of_match[] = {
-	{ .compatible = "nintendo," DRIVER_NAME, },
+	{ .compatible = "nintendo," DRIVER_NAME },
 	{}
 };
 MODULE_DEVICE_TABLE(of, ctr_spi_of_match);

--- a/drivers/platform/nintendo3ds/ctr_spi.c
+++ b/drivers/platform/nintendo3ds/ctr_spi.c
@@ -30,10 +30,10 @@ struct ctr_spi {
 
 /* CNT register bits */
 #define SPI_CNT_CHIPSELECT(n)	((n) << 6)
-#define SPI_CNT_XFER_READ		(0 << 13)
-#define SPI_CNT_XFER_WRITE		(1 << 13)
-#define SPI_CNT_BUSY			BIT(15)
-#define SPI_CNT_ENABLE			BIT(15)
+#define SPI_CNT_XFER_READ	(0 << 13)
+#define SPI_CNT_XFER_WRITE	(1 << 13)
+#define SPI_CNT_BUSY		BIT(15)
+#define SPI_CNT_ENABLE		BIT(15)
 
 #define SPI_FIFO_BUSY	BIT(0)
 #define SPI_FIFO_WIDTH	0x20
@@ -85,8 +85,8 @@ static u32 ctr_spi_read_status(struct ctr_spi *spi)
 
 static int ctr_spi_wait_busy(struct ctr_spi *spi)
 {
-	long res = wait_event_interruptible_timeout(
-		spi->wq, !(ctr_spi_read_cnt(spi) & SPI_CNT_BUSY), CTR_SPI_TIMEOUT
+	long res = wait_event_interruptible_timeout(spi->wq,
+		!(ctr_spi_read_cnt(spi) & SPI_CNT_BUSY), CTR_SPI_TIMEOUT
 	);
 
 	if (res > 0)
@@ -112,7 +112,7 @@ static int ctr_spi_done(struct ctr_spi *spi)
 }
 
 static void ctr_spi_setup_xfer(struct ctr_spi *spidrv,
-							struct spi_device *spi, bool read)
+				struct spi_device *spi, bool read)
 {
 	ctr_spi_write_cnt(spidrv, SPI_CNT_ENABLE |
 		ctr_spi_freq_to_rate(spi->max_speed_hz) |
@@ -154,8 +154,8 @@ static void ctr_spi_set_cs(struct spi_device *spi, bool enable)
 }
 
 static int ctr_spi_transfer_one(struct spi_master *master,
-								struct spi_device *spi,
-								struct spi_transfer *xfer)
+				struct spi_device *spi,
+				struct spi_transfer *xfer)
 {
 	int err;
 	bool read;

--- a/drivers/platform/nintendo3ds/ctr_spi.c
+++ b/drivers/platform/nintendo3ds/ctr_spi.c
@@ -32,8 +32,8 @@ struct ctr_spi {
 #define SPI_CNT_CHIPSELECT(n)	((n) << 6)
 #define SPI_CNT_XFER_READ	(0 << 13)
 #define SPI_CNT_XFER_WRITE	(1 << 13)
-#define SPI_CNT_BUSY	BIT(15)
-#define SPI_CNT_ENABLE	BIT(15)
+#define SPI_CNT_BUSY		BIT(15)
+#define SPI_CNT_ENABLE		BIT(15)
 
 #define SPI_FIFO_BUSY	BIT(0)
 #define SPI_FIFO_WIDTH	0x20
@@ -169,10 +169,10 @@ static int ctr_spi_transfer_one(struct spi_master *master,
 
 	if (xfer->tx_buf) {
 		read = false;
-		buf = (u32 *)xfer->tx_buf;
+		buf = (u32*)xfer->tx_buf;
 	} else if (xfer->rx_buf) {
 		read = true;
-		buf = (u32 *)xfer->rx_buf;
+		buf = (u32*)xfer->rx_buf;
 	} else {
 		return -EINVAL;
 	}

--- a/drivers/platform/nintendo3ds/ctr_tsc.c
+++ b/drivers/platform/nintendo3ds/ctr_tsc.c
@@ -6,8 +6,8 @@
  * chip used in the Nintendo (3)DS consoles
  */
 
-#define DRIVER_NAME	"3ds-tsc"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define DRIVER_NAME "3ds-tsc"
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/delay.h>
 #include <linux/kernel.h>
@@ -40,8 +40,7 @@ static int ctr_tsc_switch_bank(struct ctr_tsc *cdc, const u8 *bank)
 	return err;
 }
 
-static int ctr_tsc_read(void *context,
-			const void *reg_buf, size_t reg_len,
+static int ctr_tsc_read(void *context, const void *reg_buf, size_t reg_len,
 			void *val_buf, size_t val_len)
 {
 	int err;
@@ -72,8 +71,7 @@ static int ctr_tsc_write(void *context, const void *data, size_t len)
 	return spi_write(cdc->spi, data + 1, len - 1);
 }
 
-static int ctr_tsc_gather_write(void *context,
-				const void *reg, size_t reg_len,
+static int ctr_tsc_gather_write(void *context, const void *reg, size_t reg_len,
 				const void *val, size_t val_len)
 {
 	int err;
@@ -123,7 +121,7 @@ static const struct regmap_config ctr_tsc_map_cfg = {
 static int ctr_tsc_sw_reset(struct ctr_tsc *cdc)
 {
 	/* bank 0, register 1, write 1 */
-	static const u8 cdc_init_data[] = {0x00, (1 << 1) | 1, 0x01};
+	static const u8 cdc_init_data[] = { 0x00, (1 << 1) | 1, 0x01 };
 	return ctr_tsc_write(cdc, cdc_init_data, 3);
 }
 

--- a/drivers/platform/nintendo3ds/ctr_tsc.c
+++ b/drivers/platform/nintendo3ds/ctr_tsc.c
@@ -73,8 +73,8 @@ static int ctr_tsc_write(void *context, const void *data, size_t len)
 }
 
 static int ctr_tsc_gather_write(void *context,
-										const void *reg, size_t reg_len,
-										const void *val, size_t val_len)
+				const void *reg, size_t reg_len,
+				const void *val, size_t val_len)
 {
 	int err;
 	struct spi_transfer xfer[2];

--- a/drivers/platform/nintendo3ds/mcu/accel.c
+++ b/drivers/platform/nintendo3ds/mcu/accel.c
@@ -5,8 +5,8 @@
  * Copyright (C) 2021 Santiago Herrera
  */
 
-#define DRIVER_NAME	"3dsmcu-accel"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define DRIVER_NAME "3dsmcu-accel"
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 /*
  * the hardware device is actually an ST LIS331DLH which is
@@ -53,7 +53,7 @@ struct ctr_accel {
 static int ctr_accel_set_power(struct ctr_accel *acc, int pwr)
 {
 	int err = regmap_write(acc->map, acc->io_addr + REG_MODE,
-		pwr > 0 ? ACCELEROMETER_ON : ACCELEROMETER_OFF);
+			       pwr > 0 ? ACCELEROMETER_ON : ACCELEROMETER_OFF);
 
 	if (!err) {
 		acc->pwr = pwr;
@@ -73,8 +73,8 @@ static void ctr_accel_update_data(struct ctr_accel *acc)
 	if (!acc->pwr)
 		return;
 
-	err = regmap_bulk_read(acc->map, acc->io_addr + REG_DATA,
-		acc->data, sizeof(acc->data));
+	err = regmap_bulk_read(acc->map, acc->io_addr + REG_DATA, acc->data,
+			       sizeof(acc->data));
 	if (err)
 		memset(acc->data, 0, sizeof(acc->data));
 	else
@@ -82,57 +82,57 @@ static void ctr_accel_update_data(struct ctr_accel *acc)
 }
 
 static int ctr_accel_read_raw(struct iio_dev *indio_dev,
-				struct iio_chan_spec const *chan,
-				int *val, int *val2, long mask)
+			      struct iio_chan_spec const *chan, int *val,
+			      int *val2, long mask)
 {
 	int err;
 	struct ctr_accel *acc = iio_priv(indio_dev);
 
-	switch(mask) {
-		case IIO_CHAN_INFO_RAW:
-			ctr_accel_update_data(acc);
-			if (chan->address < 3) {
-				*val = sign_extend32(acc->data[chan->address], 15);
-				err = IIO_VAL_INT;
-			} else {
-				err = -EINVAL;
-			}
-			break;
-
-		case IIO_CHAN_INFO_ENABLE:
-			*val = acc->pwr;
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		ctr_accel_update_data(acc);
+		if (chan->address < 3) {
+			*val = sign_extend32(acc->data[chan->address], 15);
 			err = IIO_VAL_INT;
-			break;
-
-		case IIO_CHAN_INFO_SCALE:
-			*val = 0;
-			*val2 = CTR_ACCEL_NSCALE;
-			err = IIO_VAL_INT_PLUS_NANO;
-			break;
-
-		default:
+		} else {
 			err = -EINVAL;
-			break;
+		}
+		break;
+
+	case IIO_CHAN_INFO_ENABLE:
+		*val = acc->pwr;
+		err = IIO_VAL_INT;
+		break;
+
+	case IIO_CHAN_INFO_SCALE:
+		*val = 0;
+		*val2 = CTR_ACCEL_NSCALE;
+		err = IIO_VAL_INT_PLUS_NANO;
+		break;
+
+	default:
+		err = -EINVAL;
+		break;
 	}
 
 	return err;
 }
 
 static int ctr_accel_write_raw(struct iio_dev *indio_dev,
-				struct iio_chan_spec const *chan,
-				int val, int val2, long mask)
+			       struct iio_chan_spec const *chan, int val,
+			       int val2, long mask)
 {
 	int err;
 	struct ctr_accel *acc = iio_priv(indio_dev);
 
-	switch(mask) {
-		case IIO_CHAN_INFO_ENABLE:
-			err = ctr_accel_set_power(acc, val);
-			break;
+	switch (mask) {
+	case IIO_CHAN_INFO_ENABLE:
+		err = ctr_accel_set_power(acc, val);
+		break;
 
-		default:
-			err = -EINVAL;
-			break;
+	default:
+		err = -EINVAL;
+		break;
 	}
 
 	return err;
@@ -143,8 +143,8 @@ static const struct iio_info ctr_accel_ops = {
 	.write_raw = ctr_accel_write_raw,
 };
 
-#define CTR_ACCEL_CHANNEL(addr, subchan) \
-	{ \
+#define CTR_ACCEL_CHANNEL(addr, subchan)                                       \
+	{                                                                      \
 		.type = IIO_ACCEL, \
 		.address = (addr), \
 		.channel2 = (subchan), \
@@ -157,7 +157,7 @@ static const struct iio_info ctr_accel_ops = {
 		}, \
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW), \
 		.info_mask_shared_by_type = \
-			BIT(IIO_CHAN_INFO_SCALE) | BIT(IIO_CHAN_INFO_ENABLE), \
+			BIT(IIO_CHAN_INFO_SCALE) | BIT(IIO_CHAN_INFO_ENABLE),                                           \
 	}
 
 static const struct iio_chan_spec ctr_accel_channels[] = {
@@ -240,7 +240,7 @@ static int ctr_accel_resume(struct device *dev)
 static SIMPLE_DEV_PM_OPS(ctr_accel_pm_ops, ctr_accel_suspend, ctr_accel_resume);
 
 static const struct of_device_id ctr_accel_of_match[] = {
-	{ .compatible = "nintendo," DRIVER_NAME, },
+	{ .compatible = "nintendo," DRIVER_NAME },
 	{}
 };
 MODULE_DEVICE_TABLE(of, ctr_accel_of_match);

--- a/drivers/platform/nintendo3ds/mcu/accel.c
+++ b/drivers/platform/nintendo3ds/mcu/accel.c
@@ -82,8 +82,8 @@ static void ctr_accel_update_data(struct ctr_accel *acc)
 }
 
 static int ctr_accel_read_raw(struct iio_dev *indio_dev,
-							struct iio_chan_spec const *chan,
-							int *val, int *val2, long mask)
+				struct iio_chan_spec const *chan,
+				int *val, int *val2, long mask)
 {
 	int err;
 	struct ctr_accel *acc = iio_priv(indio_dev);
@@ -119,8 +119,8 @@ static int ctr_accel_read_raw(struct iio_dev *indio_dev,
 }
 
 static int ctr_accel_write_raw(struct iio_dev *indio_dev,
-								struct iio_chan_spec const *chan,
-								int val, int val2, long mask)
+				struct iio_chan_spec const *chan,
+				int val, int val2, long mask)
 {
 	int err;
 	struct ctr_accel *acc = iio_priv(indio_dev);

--- a/drivers/platform/nintendo3ds/mcu/accel.c
+++ b/drivers/platform/nintendo3ds/mcu/accel.c
@@ -157,7 +157,7 @@ static const struct iio_info ctr_accel_ops = {
 		}, \
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW), \
 		.info_mask_shared_by_type = \
-			BIT(IIO_CHAN_INFO_SCALE) | BIT(IIO_CHAN_INFO_ENABLE),                                           \
+			BIT(IIO_CHAN_INFO_SCALE) | BIT(IIO_CHAN_INFO_ENABLE),  \
 	}
 
 static const struct iio_chan_spec ctr_accel_channels[] = {

--- a/drivers/platform/nintendo3ds/mcu/charger.c
+++ b/drivers/platform/nintendo3ds/mcu/charger.c
@@ -53,7 +53,8 @@ static int battery_getprop(struct power_supply *psy,
 	switch(psp) {
 		case POWER_SUPPLY_PROP_PRESENT:
 		case POWER_SUPPLY_PROP_ONLINE:
-			val->intval = 1; /* assume there's always a battery present */
+			/* assume there's always a battery present */
+			val->intval = 1;
 			break;
 
 		case POWER_SUPPLY_PROP_STATUS:
@@ -70,8 +71,8 @@ static int battery_getprop(struct power_supply *psy,
 			break;
 
 		case POWER_SUPPLY_PROP_TEMP:
-			val->intval = sign_extend32(data[REG_TEMPERATURE], 7) * 10;
 			/* data is given in tenths of degrees celsius */
+			val->intval = sign_extend32(data[REG_TEMPERATURE], 7) * 10;
 			break;
 
 		case POWER_SUPPLY_PROP_VOLTAGE_NOW:
@@ -103,7 +104,8 @@ static int ac_getprop(struct power_supply *psy,
 			break;
 
 		case POWER_SUPPLY_PROP_ONLINE:
-			val->intval = data[REG_STATUS] & STATUS_AC_PLUGGED ? 1 : 0;
+			val->intval = data[REG_STATUS] & STATUS_AC_PLUGGED
+					? 1 : 0;
 			break;
 
 		default:

--- a/drivers/platform/nintendo3ds/mcu/charger.c
+++ b/drivers/platform/nintendo3ds/mcu/charger.c
@@ -5,7 +5,6 @@
  *  Copyright (C) 2020-2021 Santiago Herrera
  */
 
-
 #define DRIVER_NAME "3dsmcu-charger"
 #define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
@@ -39,8 +38,8 @@ static int ctr_charger_read(struct ctr_charger *psy, u8 *data)
 }
 
 static int battery_getprop(struct power_supply *psy,
-		enum power_supply_property psp,
-		union power_supply_propval *val)
+			   enum power_supply_property psp,
+			   union power_supply_propval *val)
 {
 	int err;
 	u8 data[6];
@@ -50,45 +49,44 @@ static int battery_getprop(struct power_supply *psy,
 	if (err)
 		return err;
 
-	switch(psp) {
-		case POWER_SUPPLY_PROP_PRESENT:
-		case POWER_SUPPLY_PROP_ONLINE:
-			/* assume there's always a battery present */
-			val->intval = 1;
-			break;
+	switch (psp) {
+	case POWER_SUPPLY_PROP_PRESENT:
+	case POWER_SUPPLY_PROP_ONLINE:
+		/* assume there's always a battery present */
+		val->intval = 1;
+		break;
 
-		case POWER_SUPPLY_PROP_STATUS:
-			if (data[REG_STATUS] & STATUS_BAT_CHARGING)
-				val->intval = POWER_SUPPLY_STATUS_CHARGING;
-			else if (data[REG_STATUS] & STATUS_AC_PLUGGED)
-				val->intval = POWER_SUPPLY_STATUS_FULL;
-			else
-				val->intval = POWER_SUPPLY_STATUS_DISCHARGING;
-			break;
+	case POWER_SUPPLY_PROP_STATUS:
+		if (data[REG_STATUS] & STATUS_BAT_CHARGING)
+			val->intval = POWER_SUPPLY_STATUS_CHARGING;
+		else if (data[REG_STATUS] & STATUS_AC_PLUGGED)
+			val->intval = POWER_SUPPLY_STATUS_FULL;
+		else
+			val->intval = POWER_SUPPLY_STATUS_DISCHARGING;
+		break;
 
-		case POWER_SUPPLY_PROP_CAPACITY:
-			val->intval = data[REG_CAPACITY];
-			break;
+	case POWER_SUPPLY_PROP_CAPACITY:
+		val->intval = data[REG_CAPACITY];
+		break;
 
-		case POWER_SUPPLY_PROP_TEMP:
-			/* data is given in tenths of degrees celsius */
-			val->intval = sign_extend32(data[REG_TEMPERATURE], 7) * 10;
-			break;
+	case POWER_SUPPLY_PROP_TEMP:
+		/* data is given in tenths of degrees celsius */
+		val->intval = sign_extend32(data[REG_TEMPERATURE], 7) * 10;
+		break;
 
-		case POWER_SUPPLY_PROP_VOLTAGE_NOW:
-			val->intval = ((unsigned)data[REG_VOLTAGE]) * 20000;
-			/* units are given in 20mV steps */
-			break;
+	case POWER_SUPPLY_PROP_VOLTAGE_NOW:
+		val->intval = ((unsigned)data[REG_VOLTAGE]) * 20000;
+		/* units are given in 20mV steps */
+		break;
 
-		default:
-			return -EINVAL;
+	default:
+		return -EINVAL;
 	}
 	return 0;
 }
 
-static int ac_getprop(struct power_supply *psy,
-		enum power_supply_property psp,
-		union power_supply_propval *val)
+static int ac_getprop(struct power_supply *psy, enum power_supply_property psp,
+		      union power_supply_propval *val)
 {
 	int err;
 	u8 data[6];
@@ -98,18 +96,17 @@ static int ac_getprop(struct power_supply *psy,
 	if (err)
 		return err;
 
-	switch(psp) {
-		case POWER_SUPPLY_PROP_PRESENT:
-			val->intval = 1;
-			break;
+	switch (psp) {
+	case POWER_SUPPLY_PROP_PRESENT:
+		val->intval = 1;
+		break;
 
-		case POWER_SUPPLY_PROP_ONLINE:
-			val->intval = data[REG_STATUS] & STATUS_AC_PLUGGED
-					? 1 : 0;
-			break;
+	case POWER_SUPPLY_PROP_ONLINE:
+		val->intval = data[REG_STATUS] & STATUS_AC_PLUGGED ? 1 : 0;
+		break;
 
-		default:
-			return -EINVAL;
+	default:
+		return -EINVAL;
 	}
 	return 0;
 }

--- a/drivers/platform/nintendo3ds/mcu/intc.c
+++ b/drivers/platform/nintendo3ds/mcu/intc.c
@@ -5,8 +5,8 @@
  *  Copyright (C) 2021 Santiago Herrera
  */
 
-#define DRIVER_NAME	"3dsmcu-intc"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define DRIVER_NAME "3dsmcu-intc"
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/of.h>
 #include <linux/kernel.h>
@@ -96,8 +96,8 @@ static int ctr_mcu_intc_probe(struct platform_device *pdev)
 
 	irqc->init_ack_masked = true;
 
-	return devm_regmap_add_irq_chip_fwnode(dev, dev_fwnode(dev),
-		map, irq, 0, 0, irqc, &data);
+	return devm_regmap_add_irq_chip_fwnode(dev, dev_fwnode(dev), map, irq,
+					       0, 0, irqc, &data);
 }
 
 static const struct of_device_id ctr_mcu_intc_of_match[] = {

--- a/drivers/platform/nintendo3ds/mcu/led.c
+++ b/drivers/platform/nintendo3ds/mcu/led.c
@@ -38,7 +38,7 @@ static void ctr_led_build_data(u8 *data, u8 r, u8 g, u8 b)
 }
 
 static int ctr_led_brightness_set_blocking(struct led_classdev *cdev,
-											enum led_brightness brightness)
+					enum led_brightness brightness)
 {
 	u8 data[100];
 	struct ctr_led *led;

--- a/drivers/platform/nintendo3ds/mcu/led.c
+++ b/drivers/platform/nintendo3ds/mcu/led.c
@@ -5,8 +5,8 @@
  * Copyright (C) 2020-2021 Santiago Herrera
  */
 
-#define DRIVER_NAME	"3dsmcu-led"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define DRIVER_NAME "3dsmcu-led"
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/of.h>
 #include <linux/kernel.h>
@@ -38,7 +38,7 @@ static void ctr_led_build_data(u8 *data, u8 r, u8 g, u8 b)
 }
 
 static int ctr_led_brightness_set_blocking(struct led_classdev *cdev,
-					enum led_brightness brightness)
+					   enum led_brightness brightness)
 {
 	u8 data[100];
 	struct ctr_led *led;
@@ -47,11 +47,9 @@ static int ctr_led_brightness_set_blocking(struct led_classdev *cdev,
 	led_mc_calc_color_components(mc_cdev, brightness);
 
 	led = container_of(mc_cdev, struct ctr_led, led);
-	ctr_led_build_data(data,
-		led->subled[0].brightness,
-		led->subled[1].brightness,
-		led->subled[2].brightness
-	);
+	ctr_led_build_data(data, led->subled[0].brightness,
+			   led->subled[1].brightness,
+			   led->subled[2].brightness);
 
 	return regmap_bulk_write(led->map, led->io_addr, data, 100);
 }
@@ -88,7 +86,8 @@ static int ctr_led_probe(struct platform_device *pdev)
 	/* initialize main led class */
 	mc_led->led_cdev.name = dev_name(dev);
 	mc_led->led_cdev.max_brightness = 255;
-	mc_led->led_cdev.brightness_set_blocking = ctr_led_brightness_set_blocking;
+	mc_led->led_cdev.brightness_set_blocking =
+		ctr_led_brightness_set_blocking;
 
 	/* initialize led subchannels */
 	mc_led->num_colors = 3;

--- a/drivers/platform/nintendo3ds/mcu/regulator.c
+++ b/drivers/platform/nintendo3ds/mcu/regulator.c
@@ -5,8 +5,8 @@
  * Copyright (C) 2021 Santiago Herrera
  */
 
-#define DRIVER_NAME	"3dsmcu-regulator"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define DRIVER_NAME "3dsmcu-regulator"
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/of.h>
 #include <linux/kernel.h>
@@ -83,7 +83,7 @@ static int ctr_regulator_remove(struct platform_device *pdev)
 }
 
 static const struct of_device_id ctr_regulator_of_match[] = {
-	{ .compatible = "nintendo," DRIVER_NAME, },
+	{ .compatible = "nintendo," DRIVER_NAME },
 	{}
 };
 MODULE_DEVICE_TABLE(of, ctr_regulator_of_match);

--- a/drivers/platform/nintendo3ds/mcu/rtc.c
+++ b/drivers/platform/nintendo3ds/mcu/rtc.c
@@ -5,8 +5,8 @@
  * Copyright (C) 2020-2021 Santiago Herrera
  */
 
-#define DRIVER_NAME	"3dsmcu-rtc"
-#define pr_fmt(fmt)	DRIVER_NAME ": " fmt
+#define DRIVER_NAME "3dsmcu-rtc"
+#define pr_fmt(fmt) DRIVER_NAME ": " fmt
 
 #include <linux/of.h>
 #include <linux/bcd.h>
@@ -32,12 +32,12 @@ static int ctr_rtc_get_time(struct device *dev, struct rtc_time *tm)
 	if (err)
 		return err;
 
-	tm->tm_sec	= bcd2bin(buf[0]) % 60;
-	tm->tm_min	= bcd2bin(buf[1]) % 60;
-	tm->tm_hour	= bcd2bin(buf[2]) % 24;
-	tm->tm_mday	= bcd2bin(buf[4]) % 32;
-	tm->tm_mon	= (bcd2bin(buf[5]) - 1) % 12;
-	tm->tm_year	= bcd2bin(buf[6]) + 100;
+	tm->tm_sec = bcd2bin(buf[0]) % 60;
+	tm->tm_min = bcd2bin(buf[1]) % 60;
+	tm->tm_hour = bcd2bin(buf[2]) % 24;
+	tm->tm_mday = bcd2bin(buf[4]) % 32;
+	tm->tm_mon = (bcd2bin(buf[5]) - 1) % 12;
+	tm->tm_year = bcd2bin(buf[6]) + 100;
 	return 0;
 }
 
@@ -57,8 +57,8 @@ static int ctr_rtc_set_time(struct device *dev, struct rtc_time *tm)
 }
 
 static const struct rtc_class_ops ctr_rtc_ops = {
-	.read_time	= ctr_rtc_get_time,
-	.set_time	= ctr_rtc_set_time,
+	.read_time = ctr_rtc_get_time,
+	.set_time = ctr_rtc_set_time,
 };
 
 static int ctr_rtc_probe(struct platform_device *pdev)
@@ -97,7 +97,7 @@ static int ctr_rtc_remove(struct platform_device *pdev)
 }
 
 static const struct of_device_id ctr_rtc_of_match[] = {
-	{ .compatible = "nintendo," DRIVER_NAME, },
+	{ .compatible = "nintendo," DRIVER_NAME },
 	{}
 };
 MODULE_DEVICE_TABLE(of, ctr_rtc_of_match);


### PR DESCRIPTION
these changes make sure all lines stay within the 80 char limit (soon to be changed to 120 anyway) when using 8 character wide tabulations.

there's a few spots where they're still wider, but it's so minor I don't think it's a problem.

the main point of this PR is to improve legibility where it's clearly broken.

no functionality was changed.