### PR TITLE
ARM: dts: nintendo3ds: Provide initrd location in chosen

### DIFF
--- a/arch/arm/boot/dts/nintendo3ds_ctr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ctr.dts
@@ -38,6 +38,9 @@
 
 	chosen {
 		bootargs = "keep_bootcon fbcon=rotate:1";
+		// At the end of the fcram
+		linux,initrd-start = <0x27800000>;
+		linux,initrd-end = <0x28000000>; // 8 MiB
 	};
 };
 

--- a/arch/arm/boot/dts/nintendo3ds_ktr.dts
+++ b/arch/arm/boot/dts/nintendo3ds_ktr.dts
@@ -50,5 +50,8 @@
 
 	chosen {
 		bootargs = "keep_bootcon fbcon=rotate:1";
+		// At the end of the CTR fcram
+		linux,initrd-start = <0x27800000>;
+		linux,initrd-end = <0x28000000>; // 8 MiB
 	};
 };


### PR DESCRIPTION
This sets the initrd location to the location hardcoded in
firm_linux_loader.

The chosen location is arbitrary, 8 MiB at the end of the CTR FCRAM. Note that this does not mean these 8 MiB are reserved and not usable! The memory is released once the initrd has been used.

See: https://github.com/linux-3ds/firm_linux_loader/pull/27