### PR TITLE
fix CTR_TSC_TOUCH dependencies

### DIFF
--- a/drivers/platform/nintendo3ds/Kconfig
+++ b/drivers/platform/nintendo3ds/Kconfig
@@ -60,6 +60,10 @@ config CTR_TSC_TOUCH
 	tristate "Nintendo 3DS touchscreen/circlepad driver"
 	depends on CTR_TSC
 	select INPUT_POLLDEV
+	select FB
+	select FRAMEBUFFER_CONSOLE
+	select FONTS
+	select FONT_10x18
 	default y
 	help
 	  TODO


### PR DESCRIPTION
makes sure that the 10x18 font is always available when the touchscreen driver is enabled. this prevents build/linking errors. happened to me when i was rebasing this kernel on v5.15.72.